### PR TITLE
TILES-583 changed the broken link

### DIFF
--- a/src/site/apt/tutorial/integration/frameworks.apt
+++ b/src/site/apt/tutorial/integration/frameworks.apt
@@ -39,5 +39,5 @@ Integration with other web Frameworks
 
 
   For a closer look at custom integrations the
-  {{{https://github.com/spring-projects/spring-framework/tree/master/spring-webmvc-tiles3/src/main/java/org/springframework/web/servlet/view/tiles3}spring code}}:
+  {{{https://github.com/spring-projects/spring-framework/tree/v3.2.0.RELEASE/spring-webmvc-tiles3/src/main/java/org/springframework/web/servlet/view/tiles3}spring code}}:
   forms a good example.


### PR DESCRIPTION
Just changed the link in the web framework integrations page to point to the version of spring-mvc that has the sample code in it's repository. https://issues.apache.org/jira/browse/TILES-583
