### PR TITLE
Fix: squid:S1149, Synchronized classes StringBuffer shouldn't be used.

### DIFF
--- a/tiles-compat/src/main/java/org/apache/tiles/beans/SimpleMenuItem.java
+++ b/tiles-compat/src/main/java/org/apache/tiles/beans/SimpleMenuItem.java
@@ -132,7 +132,7 @@ public class SimpleMenuItem implements MenuItem, Serializable {
     /** {@inheritDoc} */
     @Override
     public String toString() {
-        StringBuffer buff = new StringBuffer("SimpleMenuItem[");
+        StringBuilder buff = new StringBuilder("SimpleMenuItem[");
 
         if (getValue() != null) {
             buff.append("value=").append(getValue()).append(", ");

--- a/tiles-core/src/main/java/org/apache/tiles/util/WildcardHelper.java
+++ b/tiles-core/src/main/java/org/apache/tiles/util/WildcardHelper.java
@@ -494,8 +494,8 @@ public class WildcardHelper {
         }
 
         Map.Entry<Integer, String> entry;
-        StringBuffer key = new StringBuffer("{0}");
-        StringBuffer ret = new StringBuffer(val);
+        StringBuilder key = new StringBuilder("{0}");
+        StringBuilder ret = new StringBuilder(val);
         String keyTmp;
         int x;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
 squid:S1149 - “Synchronized classes Vector, Hashtable, Stack and StringBuffer should not be used ”. 
 You can find more information about the issue here: 
 https://dev.eclipse.org/sonar/rules/show/squid:S1149
 Please let me know if you have any questions.
Ayman Elkfrawy.
