### PR TITLE
TILES-598: Possible NullPointerException in OptionsRenderer

### DIFF
--- a/tiles-extras/src/main/java/org/apache/tiles/extras/renderer/OptionsRenderer.java
+++ b/tiles-extras/src/main/java/org/apache/tiles/extras/renderer/OptionsRenderer.java
@@ -190,7 +190,8 @@ public final class OptionsRenderer implements Renderer {
 
 
         static boolean attemptTemplate(final String template) {
-            return !TEMPLATE_EXISTS.containsKey(template) || TEMPLATE_EXISTS.get(template);
+            Boolean found = TEMPLATE_EXISTS.get(template);
+            return found == null || found;
         }
 
         static void update(final String template, final boolean found) {


### PR DESCRIPTION
This PR fixes the NullPointerException described in TILES-598.

Instead of (erroneously) assuming a non-null cache value if the key exists, it checks the cached value for null.